### PR TITLE
Add CONTRIBUTING.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Make @harrytmthy-dev the code owner of all files
+* @harrytmthy-dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to SafeBox
+
+Thank you for considering contributing! SafeBox welcomes improvements, bug fixes, documentation updates, and feature ideas, especially from Android developers who care about performance and clean architecture.
+
+## Local Setup
+
+```bash
+git clone https://github.com/harrytmthy-dev/safebox.git
+```
+
+### Update pre-hook path
+
+`scripts/` contains shared pre-hooks for formatting and test validation. To enable it locally:
+
+```bash
+git config --local core.hooksPath scripts
+chmod +x scripts/pre-commit
+chmod +x scripts/pre-push
+```
+
+### Run Spotless
+
+```bash
+./gradlew spotlessApply --init-script gradle/init.gradle.kts --no-configuration-cache
+```
+
+## Commit & PR Guidelines
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g. `feat:`, `fix:`, `docs:`, `refactor:`).
+- Keep PRs focused and small.
+- If your change affects the public API, update `README.md` or `MIGRATION.md` accordingly.
+- GitHub Actions will automatically run tests and checks upon opening or updating a PR.
+- Ensure all checks pass before merging.
+
+### Creating a PR
+
+1. Fork the repo and create your feature branch (`git checkout -b feature/amazing-feature`)
+2. Push your changes (`git push origin feature/amazing-feature`)
+3. Open a Pull Request against the `main` branch of the original repository
+
+## Testing
+
+Run all tests locally with:
+
+```bash
+./gradlew testDebugUnitTest
+./gradlew connectedAndroidTest
+```
+
+CI runs instrumented tests automatically on:
+- Android API 26
+- Android API 34
+
+## Contributor Etiquette
+
+- Discuss major changes or feature proposals first via [Issues](https://github.com/harrytmthy-dev/safebox/issues).
+- Be respectful during reviews! We're building something safe and friendly.
+- If anything is unclear, don't hesitate to ask!
+
+## Releasing (For Maintainers)
+
+Only maintainers can perform releases:
+- Tag with semantic versioning (`v1.1.0-alpha02`)
+- Update `CHANGELOG.md`
+- Run: `./gradlew publishToMavenCentral --no-configuration-cache`
+
+---
+
+Thanks again for contributing to SafeBox! You're helping shape a faster, safer Android future.

--- a/README.md
+++ b/README.md
@@ -107,21 +107,7 @@ SafeBox is a drop-in replacement for `EncryptedSharedPreferences`.
 
 ## Contributing
 
-### Update pre-hook path
-
-`scripts/` contains shared pre-hooks for formatting and test validation. To enable it locally:
-
-```bash
-git config --local core.hooksPath scripts
-chmod +x scripts/pre-commit
-chmod +x scripts/pre-push
-```
-
-### Run Spotless
-
-```bash
-./gradlew spotlessApply --init-script gradle/init.gradle.kts --no-configuration-cache
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, formatting, testing, and PR guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

This PR adds:

- `CONTRIBUTING.md`: A dedicated contribution guide to help new contributors set up pre-hooks, follow formatting rules, and open PRs with confidence.
- `CODEOWNERS`: Ensures at least one approving review from the repository owner for PRs modifying relevant files.

## Context

The `CONTRIBUTING.md` expands on the existing pre-hook guidance already in `README.md`, and centralizes contribution rules such as commit style, PR etiquette, and release flow.

The `CODEOWNERS` file is placed in `.github/` and currently assigns ownership of all files to `@harrytmthy-dev`.

## Why it matters

- Easier onboarding for external contributors.
- Helps maintain repo quality and review structure.
- Unlocks GitHub's native enforcement for PR reviews via CODEOWNERS.