### PR TITLE
Follow-up on #3: Undeprecate SafeBox.create(...) to reflect Option A1 decision #6

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -317,6 +317,10 @@ public class SafeBox private constructor(
          *
          * This method handles secure initialization and is recommended for most use cases.
          *
+         * **Common pitfalls:**
+         * - Do NOT create multiple SafeBox instances with the same file name.
+         * - Avoid scoping SafeBox to short-lived components (e.g. ViewModel).
+         *
          * @param context The application context
          * @param fileName The name of the backing file used for persistence
          * @param keyAlias The identifier for storing the key (used to locate its encrypted form)
@@ -328,10 +332,6 @@ public class SafeBox private constructor(
          */
         @JvmOverloads
         @JvmStatic
-        @Deprecated(
-            message = "Use SafeBoxProvider.init(...) and SafeBoxProvider.get() instead.",
-            replaceWith = ReplaceWith("SafeBoxProvider.get()"),
-        )
         public fun create(
             context: Context,
             fileName: String,
@@ -362,6 +362,10 @@ public class SafeBox private constructor(
          * This is useful for testing or advanced use cases where you want to control
          * the encryption mechanism directly.
          *
+         * **Common pitfalls:**
+         * - Do NOT create multiple SafeBox instances with the same file name.
+         * - Avoid scoping SafeBox to short-lived components (e.g. ViewModel).
+         *
          * @param context The application context
          * @param fileName The name of the backing file used for persistence
          * @param keyCipherProvider Cipher used for encrypting and decrypting keys
@@ -372,10 +376,6 @@ public class SafeBox private constructor(
          */
         @JvmOverloads
         @JvmStatic
-        @Deprecated(
-            message = "Use SafeBoxProvider.init(...) and SafeBoxProvider.get() instead.",
-            replaceWith = ReplaceWith("SafeBoxProvider.get()"),
-        )
         public fun create(
             context: Context,
             fileName: String,


### PR DESCRIPTION
### Description

Removes the @Deprecated annotation from SafeBox.create(...) per Option A1 in issue #3.

Also updates the method's documentation to clarify when to use `create(...)` vs `SafeBoxProvider.get()`.

### Context

In PR #4, `create(...)` was deprecated, which aligns with Option A2. However, in #3 the team agreed to move forward with Option A1 — keeping `create(...)` but recommending `SafeBoxProvider.get()` for global use.

Fixes #6.
