### PR TITLE
feat(storage): Add instance-bound SafeBoxStateListener support to SafeBoxBlobStore

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxState.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxState.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.state
+
+import com.harrytmthy.safebox.SafeBox
+
+/**
+ * Represents the current lifecycle state of a [SafeBox] instance.
+ *
+ * These states are exposed through [SafeBoxStateListener] and help consumers track
+ * SafeBox activity, especially during asynchronous operations.
+ *
+ * @see SafeBoxStateListener
+ */
+public enum class SafeBoxState {
+
+    /**
+     * Indicates that SafeBox is idle and not currently writing to disk.
+     * This is the default resting state.
+     */
+    IDLE,
+
+    /**
+     * Indicates that SafeBox is performing a write operation.
+     * Avoid closing or deleting the SafeBox during this time.
+     */
+    WRITING,
+
+    /**
+     * Indicates that SafeBox has been closed and is no longer usable.
+     * Once closed, a SafeBox instance cannot be reused.
+     */
+    CLOSED,
+}

--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxStateListener.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxStateListener.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.state
+
+/**
+ * A listener interface for observing [SafeBoxState] changes tied to a specific SafeBox file.
+ *
+ * This is typically used in non-singleton SafeBox use cases (e.g. ViewModel-scoped),
+ * where consumers need to track if the instance is writing, idle, or closed.
+ *
+ * @see SafeBoxState
+ */
+public fun interface SafeBoxStateListener {
+
+    /**
+     * Called whenever there is a state update.
+     *
+     * @param state The latest state of the SafeBox instance.
+     */
+    fun onStateChanged(state: SafeBoxState)
+}


### PR DESCRIPTION
### Overview

This PR introduces support for **instance-scoped SafeBoxStateListener**, enabling consumers to observe the internal state of a specific `SafeBox` instance without relying on global observers.

State updates are lifecycle-bound to the instance, and automatically cleaned up during `safeBox.close()`, preventing leaks and ensuring proper teardown.

---

### Motivation

Previously, there was no way to observe what a SafeBox was doing at runtime unless you had external coordination. This addition makes it possible to:
- Display "in progress" indicators during writing.
- React to closure events in a scoped, low-overhead manner.
- Or simply track SafeBox behavior for close observations.

This is especially useful for **ViewModel-scoped SafeBox** instances that may be short-lived and tied to screen transitions.

### API

```kotlin
SafeBox.create(
    context = ctx,
    fileName = "my_prefs",
    listener = SafeBoxStateListener { state ->
        when (state) {
            WRITING -> // do something
            IDLE ->    // do something
            CLOSED -> cleanUp()
        }
    }
)
```

### Behavior Notes
- Listener receives the initial `IDLE` state upon creation.
- State changes:
  - `WRITING` during `write()` and `delete()`.
  - `IDLE` once operations complete.
  - `CLOSED` when `close()` is called.
- No manual removal is necessary. Listener is instance-bound and disposed automatically during teardown.

---

Partially addresses [#12](https://github.com/harrytmthy-dev/safebox/issues/12).
The remaining work (global observer support) will be completed in a follow-up PR.