### PR TITLE
feat(state): Add SafeBoxGlobalStateObserver and closeWhenIdle support

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/registry/SafeBoxBlobFileRegistry.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/registry/SafeBoxBlobFileRegistry.kt
@@ -17,6 +17,7 @@
 package com.harrytmthy.safebox.registry
 
 import com.harrytmthy.safebox.SafeBox
+import com.harrytmthy.safebox.state.SafeBoxGlobalStateObserver
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
@@ -27,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap
  * This ensures thread safety and prevents corruption due to concurrent `FileChannel` access.
  *
  * This registry is internal-only and not intended for external observation.
- * Please use [SafeBoxStateObserver] to listen for state changes.
+ * Please use [SafeBoxGlobalStateObserver] to listen for state changes.
  */
 internal object SafeBoxBlobFileRegistry {
 

--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxGlobalStateObserver.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxGlobalStateObserver.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.state
+
+import com.harrytmthy.safebox.state.SafeBoxGlobalStateObserver.updateState
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
+
+/**
+ * Public observer interface for monitoring SafeBox state changes.
+ *
+ * Allows clients to observe SafeBox's lifecycle state transitions for a given file name,
+ * enabling safer orchestration in multi-screen or asynchronous apps.
+ */
+public object SafeBoxGlobalStateObserver {
+
+    private val stateHolder = ConcurrentHashMap<String, SafeBoxState>()
+
+    private val listeners = ConcurrentHashMap<String, CopyOnWriteArraySet<SafeBoxStateListener>>()
+
+    /**
+     * Returns the most recently known state of the SafeBox associated with the given file name.
+     *
+     * This value reflects the latest emitted state via [updateState], even if no active listener
+     * was registered at the time of the change.
+     *
+     * @param fileName The file name being observed.
+     * @return The last known [SafeBoxState], or `null` if the file name has never been registered.
+     */
+    @JvmStatic
+    public fun getCurrentState(fileName: String): SafeBoxState? =
+        stateHolder[fileName]
+
+    /**
+     * Adds a listener for the given SafeBox file name. The listener will immediately receive
+     * the current state (if any), followed by all future updates.
+     *
+     * @param fileName The name of the SafeBox file to observe.
+     * @param listener The listener to be notified of state changes.
+     */
+    @JvmStatic
+    public fun addListener(fileName: String, listener: SafeBoxStateListener) {
+        listeners.getOrPut(fileName, defaultValue = { CopyOnWriteArraySet() }).add(listener)
+        stateHolder[fileName]?.let(listener::onStateChanged)
+    }
+
+    /**
+     * Removes a previously registered listener for a specific file.
+     *
+     * @param fileName The file name being observed.
+     * @param listener The listener to remove.
+     */
+    @JvmStatic
+    public fun removeListener(fileName: String, listener: SafeBoxStateListener) {
+        listeners[fileName]?.remove(listener)
+    }
+
+    /**
+     * Emits a new state for the given file name, updating internal records
+     * and notifying all registered listeners for that file.
+     *
+     * This method is called internally by SafeBox and SafeBoxBlobFileRegistry
+     * to reflect changes in the instance's lifecycle.
+     *
+     * @param fileName The file name whose state has changed.
+     * @param newState The new [SafeBoxState] to emit.
+     */
+    internal fun updateState(fileName: String, newState: SafeBoxState) {
+        stateHolder[fileName] = newState
+        listeners[fileName]?.forEach { it.onStateChanged(newState) }
+    }
+}

--- a/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxState.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/state/SafeBoxState.kt
@@ -29,20 +29,29 @@ import com.harrytmthy.safebox.SafeBox
 public enum class SafeBoxState {
 
     /**
-     * Indicates that SafeBox is idle and not currently writing to disk.
-     * This is the default resting state.
+     * Indicates that SafeBox has been successfully created and currently loading persisted data
+     * from disk into memory.
+     *
+     * During this state, SafeBox is not yet ready to serve read or write operations.
+     * Any read/write call will be suspended until the state transitions to [IDLE].
+     */
+    STARTING,
+
+    /**
+     * Indicates that SafeBox is ready and currently idle, with no active write operations.
+     * This is the default state after initialization completes and between writes.
      */
     IDLE,
 
     /**
-     * Indicates that SafeBox is performing a write operation.
+     * Indicates that SafeBox is currently writing data to disk.
      * Avoid closing or deleting the SafeBox during this time.
      */
     WRITING,
 
     /**
      * Indicates that SafeBox has been closed and is no longer usable.
-     * Once closed, a SafeBox instance cannot be reused.
+     * To access the same file again, a new SafeBox instance must be created.
      */
     CLOSED,
 }

--- a/safebox/src/test/java/com/harrytmthy/safebox/state/SafeBoxGlobalStateObserverTest.kt
+++ b/safebox/src/test/java/com/harrytmthy/safebox/state/SafeBoxGlobalStateObserverTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.state
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SafeBoxGlobalStateObserverTest {
+
+    private val fileName = "test_box"
+
+    private lateinit var receivedStates: MutableList<SafeBoxState>
+
+    private lateinit var listener: SafeBoxStateListener
+
+    @BeforeTest
+    fun setUp() {
+        receivedStates = mutableListOf()
+        listener = SafeBoxStateListener { receivedStates.add(it) }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        SafeBoxGlobalStateObserver.removeListener(fileName, listener)
+        receivedStates.clear()
+    }
+
+    @Test
+    fun addListener_shouldImmediatelyReceiveCurrentState() {
+        SafeBoxGlobalStateObserver.updateState(fileName, SafeBoxState.WRITING)
+        SafeBoxGlobalStateObserver.addListener(fileName, listener)
+        assertEquals(listOf(SafeBoxState.WRITING), receivedStates)
+    }
+
+    @Test
+    fun updateState_shouldNotifyAllListeners() {
+        SafeBoxGlobalStateObserver.addListener(fileName, listener)
+        SafeBoxGlobalStateObserver.updateState(fileName, SafeBoxState.WRITING)
+        SafeBoxGlobalStateObserver.updateState(fileName, SafeBoxState.IDLE)
+
+        assertEquals(listOf(SafeBoxState.WRITING, SafeBoxState.IDLE), receivedStates)
+    }
+
+    @Test
+    fun getCurrentState_shouldReturnLatestState() {
+        SafeBoxGlobalStateObserver.updateState(fileName, SafeBoxState.WRITING)
+        val result = SafeBoxGlobalStateObserver.getCurrentState(fileName)
+        assertEquals(SafeBoxState.WRITING, result)
+    }
+
+    @Test
+    fun getCurrentState_shouldReturnNullForUnknownFile() {
+        val result = SafeBoxGlobalStateObserver.getCurrentState("unknown_file")
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
### Summary

This update introduces:

- ✅ `SafeBoxGlobalStateObserver` for global state tracking (`STARTING`, `WRITING`, `IDLE`, `CLOSED`)
- ✅ `closeWhenIdle()` method to ensure file is closed only when all pending writes have completed

This improves lifecycle safety in non-singleton environments (e.g. ViewModel-scoped SafeBox).

### Implementation Details
- Added a new `STARTING` state to differentiate the initial load vs uninitialized state (null).
- `SafeBoxBlobStore` now tracks a `MutableStateFlow` write counter
- `SafeBox.closeWhenIdle()` delegates safely using `safeBoxScope.launch`
- Global observer holds and emits latest state on subscription

Closes part of #12 (will be completed in global state listener PR)