### PR TITLE
fix(pipeline): Verify GPG and secret injection in publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Copy CI gradle.properties
@@ -26,7 +26,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Setup Gradle
+      - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: Clean project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Inject secrets into gradle.properties
+        run: |
+          mkdir -p ~/.gradle
+          echo "signing.keyId=${{ secrets.SIGNING_KEY_ID }}" >> ~/.gradle/gradle.properties
+          echo "signing.password=${{ secrets.SIGNING_PASSWORD }}" >> ~/.gradle/gradle.properties
+          echo "signing.secretKeyRingFile=/home/runner/.gnupg/secring.gpg" >> ~/.gradle/gradle.properties
+          echo "mavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }}" >> ~/.gradle/gradle.properties
+          echo "mavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}" >> ~/.gradle/gradle.properties
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -33,11 +42,8 @@ jobs:
       - name: Set GPG key file permissions
         run: chmod 600 /home/runner/.gnupg/secring.gpg
 
+      - name: Print release version
+        run: ./gradlew properties | grep version
+
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral --no-configuration-cache --stacktrace
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signing.keyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signing.password: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_signing.secretKeyRingFile: /home/runner/.gnupg/secring.gpg


### PR DESCRIPTION
This PR updates the `publish.yml` workflow to fix the GPG key and secrets injection issue by:

- Writing secrets directly into `~/.gradle/gradle.properties`
- Ensuring proper permissions and decoding for the GPG secret key ring
- Retaining both `workflow_dispatch` and tag-based triggers for flexibility

### Test Plan
- Run manually via `workflow_dispatch` on this branch
- Confirm that `publishToMavenCentral` completes successfully