### PR TITLE
docs(readme): Update version to 1.1.0-beta01

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Even on **multiple single commits**, SafeBox remains faster:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy-dev:safebox:1.1.0-alpha02")
+    implementation("io.github.harrytmthy-dev:safebox:1.1.0-beta01")
 }
 ```
 


### PR DESCRIPTION
Updates the version in the `Installation` block from `1.1.0-alpha02` to `1.1.0-beta01` following the latest release.

No functional or code changes included.