### PR TITLE
feat(keystore): Add XOR based masking to SafeSecretKey for in-memory protection

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/SafeBox.kt
@@ -164,6 +164,8 @@ public class SafeBox private constructor(
     public fun close() {
         SafeBoxBlobFileRegistry.unregister(blobStore.getFileName())
         blobStore.close()
+        keyCipherProvider.destroyKey()
+        valueCipherProvider.destroyKey()
     }
 
     /**

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
@@ -67,6 +67,10 @@ internal class ChaCha20CipherProvider(
         return plaintext
     }
 
+    override fun destroyKey() {
+        keyProvider.destroyKey()
+    }
+
     internal companion object {
         internal const val ALGORITHM = "ChaCha20"
         internal const val KEY_SIZE = 32

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherProvider.kt
@@ -37,4 +37,12 @@ public interface CipherProvider {
      * Decrypts the given [ciphertext] using the provided secret key.
      */
     fun decrypt(ciphertext: ByteArray): ByteArray
+
+    /**
+     * Destroys any associated cryptographic key material. This method is called when SafeBox
+     * is permanently closed to prevent key leakage from memory.
+     *
+     * Default implementation is a no-op.
+     */
+    fun destroyKey() = Unit
 }

--- a/safebox/src/main/java/com/harrytmthy/safebox/keystore/KeyProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/keystore/KeyProvider.kt
@@ -34,4 +34,10 @@ internal interface KeyProvider {
      * @return A non-null [SecretKey] instance.
      */
     fun getOrCreateKey(): SecretKey
+
+    /**
+     * Destroys any in-memory key material held by the implementation.
+     * This is typically used during shutdown to ensure sensitive key data is wiped from memory.
+     */
+    fun destroyKey() = Unit
 }


### PR DESCRIPTION
### Summary

This PR introduces XOR-based in-memory masking to `SafeSecretKey`, strengthening the protection of the Data Encryption Key (DEK) held in native memory.

### Motivation

Previously, the raw DEK was stored directly in a `DirectByteBuffer`, which avoided heap leaks but still exposed the unmasked key to memory inspection tools. This posed a risk in rooted or compromised environments where attackers could scrape native memory for sensitive material.

### Implementation Details

- `SafeSecretKey` now takes an additional `mask: ByteArray` parameter.
- On construction, the key is XOR-ed with the mask and stored as a **masked DEK**.
- The mask is derived from `SHA-256(encryptedDEK)`, ensuring it's:
  - Deterministic across process restarts
  - Never stored on disk
  - Unique per-encrypted DEK
- On `getEncoded()`, the masked key is XOR-ed again with the mask to reconstruct the original DEK.
- `releaseHeapCopy()` securely wipes the heap copy after cipher operations.
- `destroy()` securely zeros both masked key and mask from native memory.

### Related Issue

Closes #23