### PR TITLE
feat(crypto): Add CipherPool with SafeBoxExecutor to handle cryptographic concurrency

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/concurrent/SafeBoxExecutor.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/concurrent/SafeBoxExecutor.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.concurrent
+
+import java.util.concurrent.Executors
+
+/**
+ * Internal executor for background tasks within SafeBox, designed to isolate cryptographic or
+ * resource-sensitive operations from the main thread.
+ *
+ * The structure is extensible to support multi-threaded or categorized executors in the future.
+ */
+internal object SafeBoxExecutor {
+
+    private const val THREAD_NAME = "SafeBox-Worker"
+
+    private val singleThreadExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, THREAD_NAME).apply {
+            isDaemon = true
+            priority = Thread.NORM_PRIORITY
+        }
+    }
+
+    fun executeSingleThread(task: () -> Unit) {
+        singleThreadExecutor.execute(task)
+    }
+}

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherPool.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/CipherPool.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.cryptography
+
+import com.harrytmthy.safebox.concurrent.SafeBoxExecutor
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.crypto.Cipher
+
+/**
+ * A lightweight, coroutine-friendly object pool for [Cipher] instances.
+ *
+ * This pool ensures thread-safe and memory-efficient reuse of Cipher objects,
+ * avoiding frequent reinitialization costs while preventing race conditions.
+ *
+ * #### Behavior:
+ * - Initializes with [initialSize] Cipher instances, up to [maxSize].
+ * - If available Cipher count drops below `currentSize * (1 - loadFactor)`,
+ *   it triggers a background refill using [SafeBoxExecutor].
+ * - If all instances are in use, [acquire] blocks with exponential backoff until one is available.
+ *
+ * #### Usage:
+ * ```
+ * val cipher = cipherPool.acquire()
+ * try {
+ *     cipher.init(...)
+ *     cipher.doFinal(...)
+ * } finally {
+ *     cipherPool.release(cipher)
+ * }
+ * ```
+ *
+ * Or use [withCipher] for safer handling:
+ * ```
+ * cipherPool.withCipher { cipher ->
+ *     cipher.init(...)
+ *     cipher.doFinal(...)
+ * }
+ * ```
+ *
+ * @param initialSize Initial pool size (default: 8).
+ * @param maxSize Maximum pool size (default: 64).
+ * @param loadFactor Determines when to refill the pool (default: 0.75).
+ * @param transformation Cipher transformation string (e.g. "AES/GCM/NoPadding").
+ * @param provider Cipher provider name (e.g. "AndroidOpenSSL").
+ *
+ * @throws TimeoutException if no Cipher becomes available after max retries.
+ */
+public class CipherPool @JvmOverloads constructor(
+    initialSize: Int = DEFAULT_INITIAL_SIZE,
+    maxSize: Int = DEFAULT_MAX_SIZE,
+    loadFactor: Float = DEFAULT_LOAD_FACTOR,
+    private val transformation: String,
+    private val provider: String,
+) {
+
+    private val currentSize = AtomicInteger(initialSize.coerceAtMost(DEFAULT_MAX_SIZE))
+
+    private val maxSize: Int = maxSize.coerceAtLeast(initialSize)
+
+    private val loadFactor: Float = loadFactor.coerceAtMost(1f)
+
+    private val pool = ConcurrentLinkedQueue<Cipher>()
+
+    private val loadingMore = AtomicBoolean(false)
+
+    init {
+        repeat(currentSize.get()) {
+            pool.offer(Cipher.getInstance(transformation, provider))
+        }
+    }
+
+    /**
+     * Acquires a [Cipher] instance from the pool.
+     *
+     * If none are immediately available, it uses exponential backoff to retry
+     * until a Cipher becomes available or the timeout threshold is reached.
+     *
+     * If the remaining pool size falls below the configured load threshold and the
+     * current size is not yet at [maxSize], a background refill will be triggered.
+     *
+     * @return A reusable [Cipher] instance, ready for use.
+     * @throws TimeoutException if no instance is available after max retry delay.
+     */
+    @Throws(TimeoutException::class)
+    public fun acquire(): Cipher {
+        val cipher = awaitPollWithExponentialBackoff()
+        if (!loadingMore.get()) {
+            val currentSize = currentSize.get()
+            val loadSize = currentSize * (1f - loadFactor)
+            if (pool.size > loadSize || currentSize >= maxSize) {
+                return cipher
+            }
+            loadingMore.set(true)
+            SafeBoxExecutor.executeSingleThread {
+                for (count in 0 until currentSize) {
+                    if (currentSize + count >= maxSize) {
+                        break
+                    }
+                    pool.offer(Cipher.getInstance(transformation, provider))
+                    this.currentSize.incrementAndGet()
+                }
+                loadingMore.set(false)
+            }
+        }
+        return cipher
+    }
+
+    /**
+     * Releases a previously acquired [Cipher] instance back to the pool.
+     *
+     * Should always be called after [Cipher] is no longer in use to prevent leaks.
+     *
+     * @param cipher The [Cipher] instance to be returned to the pool.
+     */
+    public fun release(cipher: Cipher) {
+        pool.offer(cipher)
+    }
+
+    /**
+     * Safely executes a block of code with a pooled [Cipher] instance.
+     *
+     * Ensures the instance is returned to the pool after use, even if the block throws.
+     *
+     * Example usage:
+     * ```
+     * cipherPool.withCipher { cipher ->
+     *     cipher.init(...)
+     *     cipher.doFinal(...)
+     * }
+     * ```
+     *
+     * @param block The function to run with the [Cipher] instance.
+     * @throws TimeoutException if no Cipher is available within the retry limit.
+     */
+    @Throws(TimeoutException::class)
+    public inline fun <T> withCipher(crossinline block: (Cipher) -> T): T {
+        val cipher = acquire()
+        return try {
+            block(cipher)
+        } finally {
+            release(cipher)
+        }
+    }
+
+    private fun awaitPollWithExponentialBackoff(): Cipher {
+        var cipher = pool.poll()
+        if (cipher != null) {
+            return cipher
+        }
+        var retryMillis = RETRY_MILLIS
+        while (cipher == null) {
+            if (retryMillis > MAX_RETRY_MILLIS) {
+                throw TimeoutException("Failed to get Cipher instance.")
+            }
+            Thread.sleep(retryMillis)
+            retryMillis *= 2
+            cipher = pool.poll()
+        }
+        return cipher
+    }
+
+    public companion object {
+        public const val DEFAULT_INITIAL_SIZE = 8
+        public const val DEFAULT_LOAD_FACTOR = 0.75f
+        public const val DEFAULT_MAX_SIZE = 64
+        internal const val RETRY_MILLIS = 5L
+        internal const val MAX_RETRY_MILLIS = 80L
+    }
+}

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/SingletonCipherPoolProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/SingletonCipherPoolProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.cryptography
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+
+/**
+ * Provides singleton-managed [CipherPool] instances for SafeBox cryptographic providers.
+ *
+ * This central registry ensures that each supported cipher type (e.g. ChaCha20) reuses
+ * a shared pool of `Cipher` instances across SafeBox instances. This avoids redundant
+ * memory usage and improves performance under concurrent workloads.
+ */
+internal object SingletonCipherPoolProvider {
+
+    private val chaCha20CipherPool = CipherPool(
+        transformation = ChaCha20CipherProvider.TRANSFORMATION,
+        provider = BouncyCastleProvider.PROVIDER_NAME,
+    )
+
+    /**
+     * Returns a shared [CipherPool] instance.
+     */
+    fun getChaCha20CipherPool(): CipherPool = chaCha20CipherPool
+}

--- a/safebox/src/test/java/com/harrytmthy/safebox/cryptography/CipherPoolTest.kt
+++ b/safebox/src/test/java/com/harrytmthy/safebox/cryptography/CipherPoolTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Harry Timothy Tumalewa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harrytmthy.safebox.cryptography
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.Security
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.crypto.Cipher
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CipherPoolTest {
+
+    private lateinit var pool: CipherPool
+
+    @BeforeTest
+    fun setup() {
+        Security.addProvider(BouncyCastleProvider())
+        pool = CipherPool(
+            initialSize = 4,
+            maxSize = 8,
+            loadFactor = 0.75f,
+            transformation = ChaCha20CipherProvider.TRANSFORMATION,
+            provider = BouncyCastleProvider.PROVIDER_NAME,
+        )
+    }
+
+    @Test
+    fun acquire_and_release_should_work_single_threaded() {
+        val cipher = pool.acquire()
+
+        assertNotNull(cipher)
+        pool.release(cipher)
+    }
+
+    @Test
+    fun withCipher_should_provide_cipher_and_return_it() {
+        var executed = false
+
+        pool.withCipher { cipher ->
+            assertNotNull(cipher)
+            executed = true
+        }
+
+        assertTrue(executed)
+    }
+
+    @Test
+    fun cipherPool_should_expand_on_demand() {
+        val ciphers = mutableListOf<Cipher>()
+
+        repeat(6) {
+            ciphers.add(pool.acquire())
+        }
+
+        assertTrue(ciphers.size >= 6)
+        ciphers.forEach(pool::release)
+    }
+
+    @Test
+    fun should_handle_concurrent_access() {
+        val threadCount = 16
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        repeat(threadCount) {
+            executor.execute {
+                try {
+                    pool.withCipher { cipher ->
+                        assertNotNull(cipher)
+                    }
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        val completed = latch.await(5, TimeUnit.SECONDS)
+        assertTrue(completed)
+    }
+
+    @Test(expected = java.util.concurrent.TimeoutException::class)
+    fun should_throw_timeout_if_all_busy_and_max_retry_exceeded() {
+        val busyPool = CipherPool(
+            initialSize = 1,
+            maxSize = 1,
+            loadFactor = 1f,
+            transformation = ChaCha20CipherProvider.TRANSFORMATION,
+            provider = BouncyCastleProvider.PROVIDER_NAME,
+        )
+
+        val cipher = busyPool.acquire() // Occupy the only one
+        try {
+            busyPool.acquire() // Should eventually timeout
+        } finally {
+            busyPool.release(cipher)
+        }
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces a new `CipherPool` class to support concurrent encryption and decryption in thread-safe SafeBox components, particularly for ChaCha20-based operations.

While previous versions used synchronized access to a single `Cipher` instance, this approach blocks multiple readers and bottlenecks under load. The new pooling system allows safe parallel access across threads while managing lifecycle and memory limits.

Key Design Decisions:
- Max pool size capped at 64
- Load factor controls early expansion before saturation
- Background expansion is handled by `SafeBoxExecutor` to avoid blocking active threads

### Future Work
- Consider LRU-style trimming to release idle Ciphers
- Expand `SafeBoxExecutor` into configurable thread pools if needed

---

Closes #25