### PR TITLE
refactor(crypto): Change BouncyCastleProvider init behavior

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/ChaCha20CipherProvider.kt
@@ -21,9 +21,7 @@ import android.security.keystore.KeyProperties.DIGEST_SHA256
 import com.harrytmthy.safebox.keystore.KeyProvider
 import com.harrytmthy.safebox.keystore.SafeSecretKey
 import org.bouncycastle.jcajce.spec.AEADParameterSpec
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.MessageDigest
-import java.security.Security
 import javax.crypto.Cipher
 
 /**
@@ -81,10 +79,5 @@ internal class ChaCha20CipherProvider(
         internal const val TRANSFORMATION = "ChaCha20-Poly1305"
         private const val IV_SIZE = 12
         private const val MAC_SIZE_BITS = 128
-
-        init {
-            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-            Security.addProvider(BouncyCastleProvider())
-        }
     }
 }

--- a/safebox/src/main/java/com/harrytmthy/safebox/cryptography/SingletonCipherPoolProvider.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/cryptography/SingletonCipherPoolProvider.kt
@@ -17,6 +17,9 @@
 package com.harrytmthy.safebox.cryptography
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.GeneralSecurityException
+import java.security.Security
+import javax.crypto.Cipher
 
 /**
  * Provides singleton-managed [CipherPool] instances for SafeBox cryptographic providers.
@@ -28,8 +31,21 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 internal object SingletonCipherPoolProvider {
 
     private val chaCha20CipherPool = CipherPool(
-        transformation = ChaCha20CipherProvider.TRANSFORMATION,
-        provider = BouncyCastleProvider.PROVIDER_NAME,
+        getCipherInstance = {
+            try {
+                Cipher.getInstance(
+                    ChaCha20CipherProvider.TRANSFORMATION,
+                    BouncyCastleProvider.PROVIDER_NAME,
+                )
+            } catch (_: GeneralSecurityException) {
+                Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+                Security.addProvider(BouncyCastleProvider())
+                Cipher.getInstance(
+                    ChaCha20CipherProvider.TRANSFORMATION,
+                    BouncyCastleProvider.PROVIDER_NAME,
+                )
+            }
+        },
     )
 
     /**


### PR DESCRIPTION
### Summary
This PR refactors how SafeBox integrates with BouncyCastleProvider to avoid global, unsafe modifications.

### Changes
- **CipherPool** now accepts a `getCipherInstance` lambda to allow on-demand and fallback-safe instantiation.
- `SingletonCipherPoolProvider` now gracefully injects BouncyCastleProvider **only if missing**, inside a `try-catch`.
- This ensures no premature provider replacement and better compatibility with host apps or other libraries.

---

Closes #1