### PR TITLE
refactor: Bump compileSdk to 36

### DIFF
--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -27,7 +27,7 @@ version = "1.1.0-beta01"
 
 android {
     namespace = "com.harrytmthy.safebox"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 23


### PR DESCRIPTION
## Summary

This PR bumps the `compileSdk` versions to API level 36.

Closes #2