### PR TITLE
chore: Enable GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: harrytmthy-dev

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ Even on **multiple single commits**, SafeBox remains faster:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, formatting, testing, and PR guidelines.
 
+## 💖 Support SafeBox
+
+If SafeBox helped secure your app or saved your time, consider sponsoring to support future improvements and maintenance!
+
+[![Sponsor](https://img.shields.io/badge/sponsor-%F0%9F%92%96-blueviolet?style=flat-square)](https://github.com/sponsors/harrytmthy-dev)
+
 ## License
 
 ```


### PR DESCRIPTION
### Summary

Now that SafeBox has been officially accepted into the **GitHub Sponsors** program, it's time to publicly show our support button on the repository. This allows users and developers who find SafeBox valuable to contribute toward its continued development, maintenance, and upcoming improvements.