### PR TITLE
fix(proguard): Add missing consumer rules for BouncyCastle

### DIFF
--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -32,6 +32,7 @@ android {
     defaultConfig {
         minSdk = 23
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("proguard-consumer-rules.pro")
     }
 
     buildTypes {

--- a/safebox/proguard-consumer-rules.pro
+++ b/safebox/proguard-consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class org.bouncycastle.** { *; }


### PR DESCRIPTION
### Summary

Bundles a default `proguard-consumer-rules.pro` in the SafeBox AAR to prevent crashes during R8 builds, as reported in #51.

### Implementation Details

- Added `proguard-consumer-rules.pro` to the `:safebox` module.
- Included `-keep class org.bouncycastle.** { *; }` to preserve required classes for BouncyCastle during minification.
- Verified that the rule is correctly bundled by unzipping the release AAR and checking `proguard.txt`.

Closes #51