### PR TITLE
release: v1.1.1 with additional consumer rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2025-08-16
+
+### Fixed
+- **ProGuard consumer rules missing**: SafeBox now ships with a default `proguard-consumer-rules.pro` to prevent crashes during R8 shrinking. This fix ensures SafeBox's BouncyCastle usage does not get stripped during release builds. ([#51](https://github.com/harrytmthy/safebox/issues/51))
+
 ## [1.1.0] - 2025-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Compared to EncryptedSharedPreferences:
 
 ```kotlin
 dependencies {
-    implementation("io.github.harrytmthy:safebox:1.1.0")
+    implementation("io.github.harrytmthy:safebox:1.1.1")
 }
 ```
 

--- a/safebox/build.gradle.kts
+++ b/safebox/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "io.github.harrytmthy"
-version = "1.1.0"
+version = "1.1.1"
 
 android {
     namespace = "com.harrytmthy.safebox"


### PR DESCRIPTION
### Summary

This PR finalizes the `v1.1.1` patch release of SafeBox, addressing a ProGuard configuration issue reported by the community.

---

### Highlights

#### Consumer ProGuard Rules
- Fixes build issues during R8 minification when using `SafeBox` with ChaCha20 on consumers' projects.  
([#51](https://github.com/harrytmthy-dev/safebox/issues/51))

#### Verified Fix
- `safebox-release.aar` now correctly bundles `proguard.txt` with the expected `-keep` rules.