### PR TITLE
fix(crypto): Serialize key usage during encrypt/decrypt to prevent AEADBadTagException

### DIFF
--- a/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
+++ b/safebox/src/androidTest/java/com/harrytmthy/safebox/SafeBoxTest.kt
@@ -223,6 +223,26 @@ class SafeBoxTest {
         assertEquals(-1, safeBox.getInt("0", -1))
     }
 
+    @Test
+    fun apply_then_commit_whenRepeatedManyTimes_shouldReturnCorrectValues() {
+        safeBox = createSafeBox(ioDispatcher = Dispatchers.IO)
+
+        safeBox.edit().apply {
+            repeat(100) {
+                putInt(it.toString(), it)
+                if (it % 2 == 0) {
+                    apply()
+                } else {
+                    commit()
+                }
+            }
+        }
+
+        repeat(100) {
+            assertEquals(it, safeBox.getInt(it.toString(), -1))
+        }
+    }
+
     private fun createSafeBox(
         ioDispatcher: CoroutineDispatcher = UnconfinedTestDispatcher(),
         stateListener: SafeBoxStateListener? = null,


### PR DESCRIPTION
### Summary

Fix `AEADBadTagException` triggered under parallel reads or interleaved `apply()` → `commit()` by guaranteeing exclusive key use during ChaCha20-Poly1305 operations.

#### Root Cause

A race between parallel crypto operations sharing the same `SecretKey` instance and per-op cleanup via `releaseHeapCopy()`. One thread could start decrypt while another finishes and cleans the key object, causing MAC check failures.

#### Proposed Solution

Serialize `encrypt(...)` and `decrypt(...)` in `ChaCha20CipherProvider` with a per-provider lock, so key cleanup cannot overlap with an in-flight `init/doFinal`.

Refs #72