### PR TITLE
feat(storage): Add corrupted bytes handler

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/storage/IoExtensions.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/storage/IoExtensions.kt
@@ -41,6 +41,13 @@ internal fun MappedByteBuffer.shiftLeft(currentTail: Int, fromOffset: Int, toOff
     return currentTail - (fromOffset - toOffset)
 }
 
+internal fun MappedByteBuffer.repairCorruptedBytes(startOffset: Int) {
+    position(startOffset)
+    val zeros = ByteArray(capacity() - startOffset)
+    put(zeros)
+    force()
+}
+
 internal fun HashMap<Bytes, EntryMeta>.adjustOffsets(
     keys: Iterable<Bytes>,
     fromOffset: Int,


### PR DESCRIPTION
### Summary
Add corrupted bytes handler to `SafeBoxBlobStore` and `SafeBoxRecoveryBlobStore`. When the loader encounters malformed headers or truncated frames, it zero-fills the remainder and sets the next tail position, avoiding hard failure.

### Implementation Details
- Single guard on `HEADER_SIZE` before reading lengths.
- Sanity checks: negative lengths or `endOffset` overflow → repair.
- `MappedByteBuffer.repairCorruptedBytes(offset)` zeros the remainder and `force()`s.

Closes #148