### PR TITLE
perf(storage): Improve blob store performance via one force per dirty page

### DIFF
--- a/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/engine/SafeBoxEngine.kt
@@ -311,6 +311,7 @@ internal class SafeBoxEngine private constructor(
                 Log.e("SafeBox", "Failed to commit changes.", e)
                 false
             } finally {
+                blobStore.flushDirtyPages()
                 currentWriteBarrier.complete(Unit)
                 if (recoveryEntries.isNotEmpty() && recoveryScheduled.compareAndSet(false, true)) {
                     scheduleRecoveryEntriesWrite(DEFAULT_BACKOFF_MS)
@@ -331,6 +332,7 @@ internal class SafeBoxEngine private constructor(
             } catch (e: Exception) {
                 Log.e("SafeBox", "Failed to commit changes.", e)
             } finally {
+                blobStore.flushDirtyPages()
                 currentWriteBarrier.complete(Unit)
             }
         }.invokeOnCompletion {

--- a/safebox/src/main/java/com/harrytmthy/safebox/storage/IoExtensions.kt
+++ b/safebox/src/main/java/com/harrytmthy/safebox/storage/IoExtensions.kt
@@ -31,12 +31,10 @@ internal fun MappedByteBuffer.shiftLeft(currentTail: Int, fromOffset: Int, toOff
         val remainingBytes = ByteArray(remainingSize).apply(::get)
         position(toOffset)
         put(remainingBytes)
-        force()
     }
     val gap = currentTail - position()
     if (gap > 0) {
         put(ByteArray(gap))
-        force()
     }
     return currentTail - (fromOffset - toOffset)
 }


### PR DESCRIPTION
### Summary

This PR optimizes SafeBoxBlobStore's durability path by replacing per-operation `force()` calls with a single batched flush per dirty page. The change significantly reduces redundant I/O, especially during bursty write or delete workloads, without altering persistence guarantees or recovery semantics.

### Implementation Details

- Added an internal `dirtyPages` set to track modified pages since the last flush.
- Removed all per-entry `MappedByteBuffer.force()` calls from `write()`, `delete()`, `shiftLeft()`, and related helpers.
- Introduced a new `flushDirtyPages()` function that:
    - Calls `MappedByteBuffer.force()` **once per dirty page** under `writeMutex`.
    - Handles full `channel.force(true)` after `deleteAll()` to persist file truncation and metadata updates.
    - Clears the dirty-page set after successful flush.
- Updated the engine's `launchWriteBlocking()` and `launchWriteAsync()` to call `flushDirtyPages()` in their `finally` blocks.

Closes #150