### PR TITLE
feat(crypto): Add ByteArray encryption/decryption APIs

### DIFF
--- a/safebox-crypto/api/safebox-crypto.api
+++ b/safebox-crypto/api/safebox-crypto.api
@@ -1,10 +1,15 @@
 public final class com/harrytmthy/safebox/SafeBoxCrypto {
 	public static final field INSTANCE Lcom/harrytmthy/safebox/SafeBoxCrypto;
 	public final fun createSecret ()Ljava/lang/String;
+	public final fun createSecretBytes ()[B
 	public final fun decrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun decrypt ([B[B)[B
 	public final fun decryptOrNull (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun decryptOrNull ([B[B)[B
 	public final fun encrypt (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encrypt ([B[B)[B
 	public final fun encryptOrNull (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun encryptOrNull ([B[B)[B
 }
 
 public abstract interface class com/harrytmthy/safebox/cryptography/CipherProvider {

--- a/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/SafeBoxCryptoTest.kt
+++ b/safebox-crypto/src/androidTest/java/com/harrytmthy/safebox/SafeBoxCryptoTest.kt
@@ -19,7 +19,9 @@ package com.harrytmthy.safebox
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class SafeBoxCryptoTest {
@@ -44,5 +46,30 @@ class SafeBoxCryptoTest {
         val text = SafeBoxCrypto.decryptOrNull(encryptedText, secret)
 
         assertEquals(originalText, text)
+    }
+
+    @Test
+    fun decrypt_bytes_shouldReturnOriginalBytes() {
+        // Some pseudo-random payload
+        val original = ByteArray(4096) { i -> (i * 31 and 0xFF).toByte() }
+        val secret = SafeBoxCrypto.createSecretBytes()
+        val encrypted = SafeBoxCrypto.encrypt(original, secret)
+
+        val decrypted = SafeBoxCrypto.decrypt(encrypted, secret)
+
+        assertContentEquals(original, decrypted)
+    }
+
+    @Test
+    fun decryptOrNull_bytes_shouldReturnOriginalBytes() {
+        val original = "binary-\uD83D\uDE80".toByteArray(Charsets.UTF_8)
+        val secret = SafeBoxCrypto.createSecretBytes()
+        val encrypted = SafeBoxCrypto.encryptOrNull(original, secret)
+        assertNotNull(encrypted)
+
+        val decrypted = SafeBoxCrypto.decryptOrNull(encrypted, secret)
+
+        assertNotNull(decrypted)
+        assertContentEquals(original, decrypted)
     }
 }


### PR DESCRIPTION
### Summary

Add direct `ByteArray` encryption/decryption APIs to `SafeBoxCrypto`, reducing Base64 and UTF-8 encoding overhead for callers that already handle binary data. Existing String APIs remain intact and now delegate to the new ByteArray core.

Closes #152